### PR TITLE
React interface

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,0 +1,4 @@
+S lib/*
+B _build/*
+
+PKG js_of_ocaml lwt.react

--- a/_oasis
+++ b/_oasis
@@ -9,14 +9,27 @@ Plugins:     META (0.3)
 BuildTools:  ocamlbuild
 PostBuildCommand: ./makejs.sh
 
+Flag react
+  Description: Enable reactive plots
+  Default: true
+
 Library c3
   Path:               lib
   Modules:            C3
   BuildDepends:       js_of_ocaml,js_of_ocaml.syntax
 
+Library "c3-react"
+  FindlibName:        react
+  FindlibParent:      c3
+  Build$:             flag(react)
+  Path:               lib
+  Modules:            C3_react
+  BuildDepends:       c3, lwt.react
+
 Executable example
   Path:               example
+  Build$:             flag(react)
   MainIs:             main.ml
   CompiledObject:     byte
   Install:            false
-  BuildDepends: js_of_ocaml,js_of_ocaml.syntax,lwt,c3
+  BuildDepends: js_of_ocaml,js_of_ocaml.syntax,lwt,c3,c3.react

--- a/example/index.html
+++ b/example/index.html
@@ -33,5 +33,7 @@
     <div id="xyareastepchart"></div>
     <p>Timeseries</p>
     <div id="timeserieschart"></div>
+    <p>Timeseries with react</p>
+    <div id="timeserieschart_react"></div>
   </body>
 </html>

--- a/example/main.ml
+++ b/example/main.ml
@@ -140,6 +140,19 @@ let timeseries () =
     end in
   Lwt.async (update_graph_forever chart 0.)
 
+let timeseries_react () =
+  let open Lwt_react in
+  let signal, push = E.create () in
+  let _ =
+    C3_react.Line.make ~kind:`Timeseries ~x_format:"%m/%d" ()
+    |> C3_react.(Line.add ~segment:(Segment.make ~kind:`Line ~signal ~label:"sin(t)" ()))
+    |> C3_react.Line.render ~bindto:"#timeserieschart_react" ~flow:`All in
+  let rec f t () =
+    if t > 10. then Lwt.return ()
+    else Lwt_js.sleep 0.1 >>= fun () -> push (t, sin t) ; f (t +. 0.1) ()
+  in
+  Lwt.async (f 0.)
+
 let _ =
   Dom_html.window##onload <- Dom_html.handler
     (fun _ ->
@@ -153,5 +166,6 @@ let _ =
       xychart `Spline "#xysplinechart";
       normal ();
       timeseries ();
+      timeseries_react ();
       Js._true
     )

--- a/lib/c3_react.ml
+++ b/lib/c3_react.ml
@@ -1,0 +1,63 @@
+open Lwt_react
+
+
+module Segment = struct
+
+  type t = {
+    segment : C3.Segment.t ;
+    signal : (float * float) E.t ;
+    label : string;
+  }
+
+  let make ~signal ~label ?(base= []) ?kind () =
+    { segment = C3.Segment.make ?kind ~label ~points:base () ;
+      signal ; label
+    }
+
+  let to_segment x = x.segment
+  let to_pair_signal x = (x.label, x.signal)
+
+end
+
+module Line = struct
+
+  type t = {
+    line : C3.Line.t ;
+    signals : (string * (float * float) E.t) list ;
+  }
+
+  let make ?x_format ~kind () =
+    { line = C3.Line.make ?x_format ~kind () ; signals = [] }
+
+  let add ~segment:{Segment. segment ; signal ; label} { line ; signals } =
+    { line = C3.Line.add ~segment line ;
+      signals = (label, signal) :: signals ;
+    }
+
+  let add_group ~segments { line ; signals } =
+    { line =
+        C3.Line.add_group
+          ~segments:(List.map Segment.to_segment segments) line ;
+      signals = (List.map Segment.to_pair_signal segments) @ signals ;
+    }
+
+  type flow = [
+    | `OneInOneOut
+    | `All
+  ]
+
+  let render ~bindto ~flow t =
+    let d = C3.Line.render ~bindto t.line in
+    let flow_to = match flow with
+      | `OneInOneOut -> `OneInOneOut
+      | `All -> `Delete 0
+    in
+    let update label p =
+      let segments = [C3.Segment.make ~points:[p] ~label ()] in
+      C3.Line.flow ~segments ~flow_to d
+    in
+    List.iter (fun (l, e) ->
+      E.keep (E.map (update l) e)
+    ) t.signals
+
+end

--- a/lib/c3_react.mli
+++ b/lib/c3_react.mli
@@ -1,0 +1,41 @@
+
+module Segment : sig
+  (** A reactive line segment within a Line chart *)
+
+  type t
+  (** An unrendered line segment within a Line chart *)
+
+  val make:
+    signal:(float * float) React.E.t -> label:string ->
+    ?base:(float * float) list -> ?kind:C3.Segment.kind -> unit -> t
+  (** Create an unrendered line segment from a set of an event of points
+      and a label. By default it will render with straight lines.
+      The argument [base] allow to provide a set of starting points.
+  *)
+end
+
+module Line : sig
+  (** A reactive line chart *)
+
+  type t
+  (** An unrendered line chart *)
+
+  val make: ?x_format:string -> kind:C3.Line.kind -> unit -> t
+  (** Create an unrendered line chart, showing either `Timeseries or `XY data.
+      The ?x_format is a format string for the labels on the x axis. *)
+
+  val add: segment:Segment.t -> t -> t
+  (** Add a line segment to an unrendered line chart. *)
+
+  val add_group: segments:Segment.t list -> t -> t
+  (** Add a group of line segments to an unrendered line chart. By grouping line
+      segments they will be rendered stacked. *)
+
+  type flow = [
+    | `OneInOneOut
+    | `All
+  ]
+
+  val render: bindto:string -> flow:flow -> t -> unit
+  (** Render a line chart and start listening to the events. *)
+end

--- a/makejs.sh
+++ b/makejs.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
 cd _build/example
-js_of_ocaml --pretty --noinline --debug-info main.byte
+js_of_ocaml --pretty --noinline --debug-info +weak.js main.byte
 cd ../../example
 ln -sf ../_build/example/main.js


### PR DESCRIPTION
This adds a react interface for Segment/Line

There is a bit of a question here. I decided to add a separated interface, but I actually think it would be better integrated directly by adding a function `Segment.make_react`. The downside is that it forces dependency to react. I don't think that's much of an issue in practice.

I also think it would be interesting to add a flow mode "window" (of int) that would scroll through the updates if they get over a certain size.

I'm not sure about react for the other graphs (and I didn't really looked at the c3 interface for them).
