### PR TITLE
`flow` with `ToX` needs to be able to take a `Time t`

### DIFF
--- a/lib/c3.ml
+++ b/lib/c3.ml
@@ -292,7 +292,7 @@ let generate bindto data =
 
 type flow_to = [
   | `OneInOneOut
-  | `ToX of string
+  | `ToX of Tic.t
   | `Delete of int
 ]
 
@@ -302,7 +302,7 @@ let flow chart ?(flow_to = `OneInOneOut) cols : unit =
       (Array.of_list
         ((match flow_to with
           | `OneInOneOut -> []
-          | `ToX x -> [ "to", inject (Js.string x) ]
+          | `ToX x -> [ "to", inject (Tic.to_float x) ]
           | `Delete n -> [ "length", inject n ] )
         @ [ "columns", js_of_columns cols; "types", js_of_types cols ])
       )

--- a/lib/c3.mli
+++ b/lib/c3.mli
@@ -85,7 +85,7 @@ end
 
 type flow_to = [
   | `OneInOneOut    (** For every point added, remove the leftmost *)
-  | `ToX of string  (** Move the minimum x co-ordinate to the given value *)
+  | `ToX of [ `Time of float | `X of float ]  (** Move the minimum x co-ordinate to the given value *)
   | `Delete of int  (** Delete exactly n points from the leftmost edge *)
 ]
 


### PR DESCRIPTION
Since javascript represents `Time t` as a float which gets interpreted
as milliseconds-since-epoch (rather than seconds-since-epoch which is
the OCaml convention) we need to pass the tagged value to `flow`

Signed-off-by: David Scott dave@recoil.org
